### PR TITLE
fix: workflowのtestの監視を解除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,25 @@
 name: ci
 on: push
 jobs:
-    lint:
-        runs-on: ubuntu-latest
+  lint:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v3
-            - name: Setup
-              uses: ./.github/actions/bun
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/bun
 
-            - name: lint
-              run: bun run lint
-            - name: spell check
-              run: bun run cspell:check
-    test:
-        runs-on: ubuntu-latest
+      - name: lint
+        run: bun run lint
+      - name: spell check
+        run: bun run cspell:check
+  test:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v3
-            - name: Setup
-              uses: ./.github/actions/bun
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/bun
 
-            - name: test
-              run: bun run test
+      - name: test
+        run: bun run test:ci


### PR DESCRIPTION
closes #10 

ciのtestが`--watch`で実行されていたため終わらない設定になっていたためそれを解除