### PR TITLE
feat: add skeleton ui

### DIFF
--- a/src/components/ui/Skeleton/index.css.ts
+++ b/src/components/ui/Skeleton/index.css.ts
@@ -1,0 +1,25 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+export const skeleton = keyframes({
+  '0%': {
+    transform: 'translateX(-100%)',
+  },
+  '100%': {
+    transform: 'translateX(100%)',
+  },
+});
+
+export const skeletonItem = style({
+  'position': 'relative',
+  'backgroundColor': '#eee',
+  'overflow': 'hidden',
+  ':before': {
+    position: 'absolute',
+    animation: `${skeleton} 2s infinite`,
+    content: '""',
+    width: '100%',
+    height: '100%',
+    background:
+      'linear-gradient(90deg, #eee 25%, #fff 50%, #eee 75%, #eee 200%)',
+  },
+});

--- a/src/components/ui/Skeleton/index.stories.tsx
+++ b/src/components/ui/Skeleton/index.stories.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    width: 100,
+    height: 100,
+    rounded: 's',
+  },
+};

--- a/src/components/ui/Skeleton/index.test.tsx
+++ b/src/components/ui/Skeleton/index.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import { Skeleton } from '.';
+
+describe('Skeleton ui Component', () => {
+  it('要素が正しくレンダリングされる', () => {
+    const { container } = render(
+      <Skeleton width={100} height={100} rounded="s" />
+    );
+
+    const element = container.firstChild;
+    expect(element).toBeDefined();
+  });
+
+  it('要素のスタイルが正しく適用される', () => {
+    const { container } = render(
+      <Skeleton width={100} height={100} rounded="s" />
+    );
+
+    const element = container.firstChild;
+    expect(element).toHaveStyle('width: 100px;');
+    expect(element).toHaveStyle('height: 100px;');
+    expect(element).toHaveStyle('border-radius: 4px;');
+  });
+});

--- a/src/components/ui/Skeleton/index.tsx
+++ b/src/components/ui/Skeleton/index.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+import { skeletonItem } from './index.css';
+
+import { ROUNDED } from '@/constants/rounded';
+
+type Props = {
+  width: number;
+  height: number;
+  rounded: keyof typeof ROUNDED;
+  className?: string;
+};
+
+export const Skeleton: React.FC<Props> = ({
+  width,
+  height,
+  rounded,
+  className,
+}) => (
+  <div
+    className={clsx(skeletonItem, className)}
+    style={{
+      width: `${width}px`,
+      height: `${height}px`,
+      borderRadius: ROUNDED[rounded],
+    }}
+  />
+);


### PR DESCRIPTION
closes #35 
skeleton ui の作成

<img width="850" alt="スクリーンショット 2023-10-02 14 23 58" src="https://github.com/tosaken1116/population-trends/assets/94045195/26236139-6c71-4f15-82d5-350822135423">
