### PR TITLE
Refactor/edit eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,11 @@
           {
             "target": "./src/app/**/page.tsx",
             "from": ["./src/components/model", "./src/components/ui"]
+          },
+          {
+            "target": "./src/components/**/*",
+            "from": ["./node_modules/react-error-boundary"],
+            "message": "Don't import react-error-boundary directly, import from libs"
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,13 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".ts", ".tsx"]
+      }
+    }
+  },
   "plugins": ["import", "unused-imports", "jsx-a11y", "@typescript-eslint"],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "error",
@@ -49,7 +56,7 @@
           },
           {
             "target": "./src/components/page/**/index.tsx",
-            "from": ["./src/components/page"]
+            "from": ["./src/components/page/**/index.tsx"]
           },
           {
             "target": "./src/app/**/page.tsx",

--- a/src/components/model/PopulationChart/index.test.tsx
+++ b/src/components/model/PopulationChart/index.test.tsx
@@ -3,8 +3,8 @@ import React, { Suspense } from 'react';
 import 'cross-fetch/polyfill';
 
 import { render, waitFor } from '@testing-library/react';
+
 import '@testing-library/jest-dom';
-import { ErrorBoundary } from 'react-error-boundary';
 
 import { usePopulationChart } from './hooks';
 import {
@@ -15,6 +15,7 @@ import { PopulationChartErrorPresentation } from './presentations/error';
 import { PopulationChartLoadingPresentation } from './presentations/loading';
 
 import { ClientProvider } from '@/components/functional/QueryClient';
+import { ErrorBoundary } from '@/libs/errorBoundary';
 
 jest.mock('./hooks', () => ({
   usePopulationChart: jest.fn(() => ({

--- a/src/components/model/PopulationChart/index.tsx
+++ b/src/components/model/PopulationChart/index.tsx
@@ -2,13 +2,12 @@
 
 import { Suspense } from 'react';
 
-import { ErrorBoundary } from 'react-error-boundary';
-
 import { PopulationChartContainer } from './presentations';
 import { PopulationChartErrorPresentation } from './presentations/error';
 import { PopulationChartLoadingPresentation } from './presentations/loading';
 
 import { ClientProvider } from '@/components/functional/QueryClient';
+import { ErrorBoundary } from '@/libs/errorBoundary';
 
 export const PopulationChart: React.FC = () => (
   <ErrorBoundary fallback={<PopulationChartErrorPresentation />}>

--- a/src/components/model/PrefectureCheckBoxes/index.test.tsx
+++ b/src/components/model/PrefectureCheckBoxes/index.test.tsx
@@ -3,14 +3,15 @@ import React, { Suspense } from 'react';
 import 'cross-fetch/polyfill';
 
 import { render, waitFor } from '@testing-library/react';
+
 import '@testing-library/jest-dom';
-import { ErrorBoundary } from 'react-error-boundary';
 
 import { PrefectureCheckBoxesPresentation } from './presentations';
 import { PrefectureCheckBoxesErrorPresentation } from './presentations/error';
 import { PrefectureCheckBoxesLoadingPresentation } from './presentations/loading';
 
 import { ClientProvider } from '@/components/functional/QueryClient';
+import { ErrorBoundary } from '@/libs/errorBoundary';
 
 describe('PrefectureCheckBoxes model Component', () => {
   it('エラーの時にエラーコンポーネントが出る', async () => {


### PR DESCRIPTION
新しく以下の`eslint rule`を追加
`error boundary`を直接importしてはいけない(errorBoundaryの実装を変更しても良いように)

以下の`eslint rule`を変更
`components/page`配下のファイルにおいて他のpageコンポーネントのindex.tsxからimportできないように変更(変更前ではindex.css.tsからのimportも禁止されるため)